### PR TITLE
Highlighting current user & Support for tourist title

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -23,8 +23,8 @@ const colors = {
   "Международный гроссмейстер": "#ff0000",
   "Legendary Grandmaster": "#ff0000",
   "Легендарный гроссмейстер": "#ff0000",
-  Tourist: "#ff0000",
-  Туристический: "#ff0000",
+  Tourist: "#000000",
+  Туристический: "#000000",
 };
 
 
@@ -344,7 +344,10 @@ const colors = {
         if (index === 1) {
           let text = `${hacker.handle}`;
           let fontWeight = 700;
-         if (rank === "Legendary Grandmaster" || rank === "Легендарный гроссмейстер") {
+          if (rank === "Tourist" || rank === "Туристический") {
+            //First letter of Tourist is red
+            text = `<span style = "color:#ff0000;">${hacker.handle[0]}</span>${hacker.handle.slice(1)}`;
+          } else if (rank === "Legendary Grandmaster" || rank === "Легендарный гроссмейстер") {
             //First letter of LGM is black
             text = `<span style = "color:#000000;">${hacker.handle[0]}</span>${hacker.handle.slice(1)}`;
           } else if (rank === "Unrated," || rank === "Не рейтинге,") {

--- a/src/content.js
+++ b/src/content.js
@@ -120,7 +120,7 @@ const colors = {
             //Case where user has ranks: CM,IM,IGM,LGM and language is Russian
             userRank = `${userInfo[0].trim()} ${userInfo[2].trim()}`;
           }else {
-            //Case where user has ranks: Unrated, Newbie, Pupil, Specialist, Expert, Master
+            //Case where user has ranks: Unrated, Newbie, Pupil, Specialist, Expert, Master and Tourist
             userRank = userInfo[0].trim();
           }
            userHandle = userInfo[userInfo.length-1].trim();

--- a/src/content.js
+++ b/src/content.js
@@ -23,6 +23,8 @@ const colors = {
   "Международный гроссмейстер": "#ff0000",
   "Legendary Grandmaster": "#ff0000",
   "Легендарный гроссмейстер": "#ff0000",
+  Tourist: "#ff0000",
+  Туристический: "#ff0000",
 };
 
 
@@ -371,6 +373,11 @@ const colors = {
       //Adding last row of the table: Total Hacks
       if (index === hackerArray.length - 1) {
         insertLastRow(totals, tbody);
+      }
+      // Highlight this row if it's the current user
+      const currentUserHandle = document.querySelector('.lang-chooser > div:nth-of-type(2) > a:nth-of-type(1)').textContent.trim();
+      if (hacker.handle === currentUserHandle) {
+        row.style.backgroundColor = "#ddeeff"; // Apply highlight
       }
     });
 


### PR DESCRIPTION
1. Highlighting the current user's row: When a user is logged in and their name appears in the hacks standings table, their row will be highlighted for easy identification.
2. Support for Tourist title: Users with the title "Tourist" will now be supported, and this title will be displayed appropriately in the standings.
I have checked the changes made in the extension via using developer mode in chrome extension.
I have checked the highlighting part for a random user and it is working finely.
<img width="1729" alt="Screenshot 2024-10-09 at 7 10 22 PM" src="https://github.com/user-attachments/assets/ad2891c4-76c3-46e2-b707-a22b732f8e57">

