### PR TITLE
Improve Cache Handling for Contest Data

### DIFF
--- a/src/Cache.js
+++ b/src/Cache.js
@@ -3,13 +3,29 @@ const TIMEOUT = 45 * 1000;  // 45 seconds
 class Cache {
   constructor() {
     this.map = new Map();
+    this.timeIds = new Map(); 
   }
 
   getOr(contestId, responsePromiseGen) {
     if (!this.map.has(contestId)) {
-      this.map.set(contestId, responsePromiseGen() );
-      setTimeout(() => void this.map.delete(contestId), TIMEOUT);
+      this.map.set(contestId, responsePromiseGen());
+      const id = setTimeout(() => void this.map.delete(contestId), TIMEOUT);
+      this.timeIds.set(contestId, id);
+    } else {
+      
+      // update cached value in the background
+      responsePromiseGen().then((res) => {
+        this.map.set(contestId, res);  // Update cache with new result
+      }).catch((err) => {
+        // keep cached value
+        console.error(`Failed to refresh cache for ${contestId}:`, err);  
+      }).finally(() => {
+        clearTimeout(this.timeIds.get(contestId));
+        const id = setTimeout(() => void this.map.delete(contestId), TIMEOUT);
+        this.timeIds.set(contestId, id);
+      });
+
     }
-    return this.map.get(contestId);
+    return this.map.get(contestId); // Return the cached value immediately
   }
 }


### PR DESCRIPTION
This pull request enhances the caching mechanism in the ```Cache.js``` file

- **Old Cache Logic:** Previously, the cache would return the cached value within the timeout period and refetch the data after the timeout expired.
- **New Cache Logic:** The updated logic ensures that the cache will return the cached value within the timeout period. However, if a request is made to the cache during this period, it will return the cached value but also fetch the data again in the background and update it once the fetch is complete.

**Changes:**

- Added a timeIds map to track timeout IDs for each contest ID.
- Modified the getOr method to update the cache in the background and reset the expiration timer upon successful update or error handling.